### PR TITLE
Update release.yml to include write permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### Summary :memo:
Add write permission to the `release` job in the release workflow 

### Bugfixes :bug: (delete if dind't have any)
- Fix 403 issue from occurring during release workflow per https://github.com/softprops/action-gh-release/issues/236

### Checks
- [x] Tested Changes (tested the change on a project released based on this template)
- [ ] Stakeholder Approval
