### PR TITLE
Change the Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.7-slim
 COPY . /app
 WORKDIR /app
 RUN pip install .


### PR DESCRIPTION
### Summary :memo:
Alpine distribution of python is very slow when using `pip` to install the dependencies. For a `requirements.txt` file that includes `pandas` and `numpy`, it ran for about 25 minutes. According to [this Stack Overflow](https://stackoverflow.com/a/60086958) answer, Alpine downloads the source file and compiles them from scratch, which is inefficient. 

Changing the source image to `-slim` drops the time for that step down to 1.5 minutes.

### Details
1. Change the initial container image from `-alpine` to `-slim`.

### Bugfixes :bug: (delete if didn't have any)
- Improves installation speed of python packages in the container environment.

### Checks
- [X] Tested Changes
- [ ] Stakeholder Approval
