### PR TITLE
Remove codecov from requirements.txt

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,6 @@ flake8
 black
 isort
 pytest-cov
-codecov
 mypy
 gitchangelog
 mkdocs


### PR DESCRIPTION
https://pypi.org/codecov no longer exists because it was deleted from PyPi. https://github.com/codecov/codecov-python indicates the project is deprecated.