### PR TITLE
add macOS support for the 'docs' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ release:          ## Create a new tag for release.
 docs:             ## Build the documentation.
 	@echo "building documentation ..."
 	@$(ENV_PREFIX)mkdocs build
-	URL="site/index.html"; xdg-open $$URL || sensible-browser $$URL || x-www-browser $$URL || gnome-open $$URL
+	URL="site/index.html"; xdg-open $$URL || sensible-browser $$URL || x-www-browser $$URL || gnome-open $$URL || open $$URL
 
 .PHONY: switch-to-poetry
 switch-to-poetry: ## Switch to poetry package manager.


### PR DESCRIPTION
### Summary :memo:

This adds macOS support for the docs Makefile target.

Currently it only uses Linux-specific commands to open up the docs after generating them, causing errors for macOS users.

### Details
1. The `open` command will be called if none of the Linux-specific ones succeed. If any of them work beforehand, this will not be executed and the target will work same as before this change. 

