### PR TITLE
Add necessary permission to create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Upload Python Package
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
### Summary :memo:
- Fix bug lack of permission when create release on repo

### Details
Bug lack of permission to create release:
#### Before:
![image](https://github.com/user-attachments/assets/f31cb95b-ab7d-4219-b9ce-bde44a1be21c)
#### After:
![image](https://github.com/user-attachments/assets/e240722c-4e69-427c-aa51-ac617c2c4293)


### Ref:
- https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128
